### PR TITLE
Always set up Crashlytics logging destination

### DIFF
--- a/ios/SteamcLog/SteamcLog/Classes/SteamcLog.swift
+++ b/ios/SteamcLog/SteamcLog/Classes/SteamcLog.swift
@@ -37,11 +37,9 @@ public struct SteamcLog {
         )
 
         // Set up default destinations
-        if config.logLevel == .release {
-            crashlyticsDestination = CrashlyticsDestination(identifier: "steamclog.crashlyticsDestination")
-            setLoggingDetails(destination: &crashlyticsDestination, outputLevel: config.logLevel.crashlytics)
-            Fabric.with([Crashlytics.self])
-        }
+        crashlyticsDestination = CrashlyticsDestination(identifier: "steamclog.crashlyticsDestination")
+        setLoggingDetails(destination: &crashlyticsDestination, outputLevel: config.logLevel.crashlytics)
+        Fabric.with([Crashlytics.self])
 
         fileDestination = FileLogDestination(writeToFile: logFilePath, identifier: "steamclog.fileDestination", shouldAppend: true)
         setLoggingDetails(destination: &fileDestination, outputLevel: config.logLevel.file)


### PR DESCRIPTION
This fixes two issues:
1. Crashlytics won't be enabled if you start with a debug level other than release
2. Changing the config after initializing with something other than `release` will cause the app to crash