### PR TITLE
[24] Include message in stacktrace for fatal errors

### DIFF
--- a/ios/SteamcLog/SteamcLog/Classes/SteamcLog.swift
+++ b/ios/SteamcLog/SteamcLog/Classes/SteamcLog.swift
@@ -246,7 +246,8 @@ public struct SteamcLog {
         xcgLogger.severe(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
 
         // forcing a crash, so we get a stacktrace
-        let selector = NSSelectorFromString("\(fileName).\(functionName) (\(lineNumber)): \(message)")
+        let cleanfileName = ("\(fileName)" as NSString).lastPathComponent.replacingOccurrences(of: ".swift", with: "")
+        let selector = NSSelectorFromString("\(cleanfileName).\(functionName) - Line \(lineNumber): \(message)")
         NSObject().perform(selector)
 
         // This should never happen - convinces Swift compiler that this is a @noreturn


### PR DESCRIPTION
Closes: #24 

This fixes two issues:
1. The filename wasn't being passed around correctly
2. The crash report didn't include the crash details

This doesn't fix a more serious issue, which is that all instances of `clog.fatal` will be grouped together by Crashlytics. I'm not sure if there's a way to get around this, I've tried a number of different methods (details below) for attempting to get this to work, but it seems like we may need to rethink `fatal` in general.

Tested methods:
- Using `assertFalse` with a message
- Using the invalid selector method
- Using `fatalError` (both with and without passing in the file/line params)
