### PR TITLE
Add some more details to crashes and errors

### DIFF
--- a/SteamcLog/Classes/Destinations/SentryLogDestination.swift
+++ b/SteamcLog/Classes/Destinations/SentryLogDestination.swift
@@ -30,15 +30,21 @@ class SentryDestination: BaseQueuedDestination {
     }
 
     override open func output(logDetails: LogDetails, message: String) {
-        if logDetails.level >= .error {
-                 let event = Event(level: logDetails.level.sentryLevel)
-                 event.message = logDetails.message
-                 SentrySDK.capture(event: event)
+        if logDetails.level == .severe {
+            // Note: text from fatalError does not currently seem to be captured (might be a bug on Sentry's side)
+            // so for fatal errors also log a breadcrumb with the error text, so we at least have it somewhere, putting them in a
+            // different category, just so they stand out more
+            let breadcrumb = Breadcrumb(level: .fatal, category: "fatal")
+            breadcrumb.message = logDetails.message
+            SentrySDK.addBreadcrumb(crumb: breadcrumb)
+        } else if logDetails.level == .error {
+            let event = Event(level: logDetails.level.sentryLevel)
+            event.message = logDetails.message
+            SentrySDK.capture(event: event)
         } else {
-                 let breadcrumb = Breadcrumb(level: logDetails.level.sentryLevel, category: "steamclog")
-                 breadcrumb.message = logDetails.message
-                 SentrySDK.addBreadcrumb(crumb: breadcrumb)
+            let breadcrumb = Breadcrumb(level: logDetails.level.sentryLevel, category: "steamclog")
+            breadcrumb.message = logDetails.message
+            SentrySDK.addBreadcrumb(crumb: breadcrumb)
         }
-
     }
 }

--- a/SteamcLog/Classes/Helper/Config.swift
+++ b/SteamcLog/Classes/Helper/Config.swift
@@ -33,6 +33,9 @@ public struct Config {
     /// More info here: https://docs.sentry.io/platforms/cocoa/?platform=swift#release-health
     internal let sentryAutoSessionTracking: Bool
 
+    /// Toggles Sentry attaching stack traces  to errors. Default is true.
+    internal let sentryAttachStacktrace: Bool
+
     /*
      * Create a new SteamcLog configuration to use.
      *
@@ -52,7 +55,8 @@ public struct Config {
             identifier: String = "steamclog",
             autoRotateConfig: AutoRotateConfig = AutoRotateConfig(),
             sentryDebug: Bool = false,
-            sentryAutoSessionTracking: Bool = true) {
+            sentryAutoSessionTracking: Bool = true,
+            sentryAttachStacktrace: Bool = true) {
         self.requireRedacted = requireRedacted
         self.logLevel = logLevel
         self.identifier = identifier
@@ -60,5 +64,6 @@ public struct Config {
         self.sentryKey = sentryKey
         self.sentryDebug = sentryDebug
         self.sentryAutoSessionTracking = sentryAutoSessionTracking
+        self.sentryAttachStacktrace = sentryAttachStacktrace
     }
 }

--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -35,11 +35,14 @@ public struct SteamcLog {
         )
 
         // Set up default destinations
-        SentrySDK.start(options: [
-            "dsn": config.sentryKey,
-            "debug": config.sentryDebug,
-            "enableAutoSessionTracking": config.sentryAutoSessionTracking
-        ])
+        let options = Options()
+        options.dsn = config.sentryKey
+        options.debug = NSNumber(value: config.sentryDebug)
+        options.attachStacktrace = NSNumber(value: config.sentryAttachStacktrace)
+        options.enableAutoSessionTracking = NSNumber(value: config.sentryAutoSessionTracking)
+
+        SentrySDK.start(options: options)
+
         sentryDestination = SentryDestination(identifier: "steamclog.sentryDestination")
         setLoggingDetails(destination: &sentryDestination, outputLevel: config.logLevel.sentry)
         xcgLogger.add(destination: sentryDestination)


### PR DESCRIPTION
For: #65, #66

Currently stack traces are not included with error captures, and the text details from `fatalError` calls also seem to not be included in any way. 

The first issue there is an easy official solution, a config option that you can use to enable that in Sentry, so I just exposed that to our config struct an enabled it by default.

The second problem I couldn't find any easy way to fix the correct way (make it show up as the issue title, work even for raw `fatalError` calls), so I've added the text as a breadcrumb so it's at least there somewhere. I think we should leave #65 open and keep investigating if there is a better way to do that and maybe file an issue with the Sentry iOS SDK if there isn't.