### PR TITLE
Some tweaks to sentry logging

### DIFF
--- a/SteamcLog/Classes/Destinations/SentryLogDestination.swift
+++ b/SteamcLog/Classes/Destinations/SentryLogDestination.swift
@@ -33,8 +33,8 @@ class SentryDestination: BaseQueuedDestination {
         // Unpleasant hack: log file rotation failure is sent from inside XCGLogger (so is hard to control),
         // has the full filename in it (so is different every time), and can happen on any call-stack (because it just happens on
         // whatever call happens to rotate the log), so does not get de-duplicate well.
-        // Convert to a warning breadcumb and a fixed string error. Not fully suppressing, for now,
-        // becausue there are problaby things we could do (super verbose logging) that would exacerbate this,
+        // Convert to a warning breadcrumb and a fixed string error. Not fully suppressing, for now,
+        // because there are probably things we could do (super verbose logging) that would exacerbate this,
         // so we should be watching how frequently it happens, just in case.
         if (logDetails.level == .error) && message.contains("Unable to rotate file") {
             let breadcrumb = Breadcrumb(level: .warning, category: "steamclog")


### PR DESCRIPTION
Problem:
  There were two quality issues with how XCGLogger logs were being turned into sentry logs that were affecting debugging on some projects:
- The log rotation error always had a unique string, due to having the full filename in it, and often had a different call-stack, so would never be de-duplicated correctly. 
- Errors would not appear int he logs of other errors, due to not being a breadcrumb

Solution:
  - Catch the log rotation error (jsut by doing s string compare, unfortunately, no real cleaner way to do it without modifying XCGLogger), and turn it into a warning with the full error string, and a static reported non-fatal error.
  - Log errors as breadcrumbs as well.