### PR TITLE
[85] Use latest Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Un-released
+
+## [0.5.2]
+- Update Sentry dependency to v7.2.1 
+
+## [0.5.1]
 - Add `userReport` to allow sending dynamic user reports to Sentry. (#71)
 
 ## [0.4.0]
 - Change `fatal` and `error` level log events to accept only `StaticString` messages to prevent duplicate issue creation with Sentry.
-- Add optional `info` parameter to log dynamic strings along with `fatal` and `error` logs. 
+- Add optional `info` parameter to log dynamic strings along with `fatal` and `error` logs.
 
 ## [0.3.2]
 - Add `Codable` conformance to `LogLevelPreset`.

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "5e17bd5b580ec2d6350f72081cb1c3fca4dc5b3a",
-          "version": "5.2.0"
+          "revision": "0ef2893efb9b27d471fa3e4e0ccd199ec7a5e726",
+          "version": "7.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/DaveWoodCom/XCGLogger", from: "7.0.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "5.1.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "7.0.0"),
     ],
     targets: [
         .target(

--- a/SteamcLog.podspec
+++ b/SteamcLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SteamcLog'
-  s.version          = '0.5.1'
+  s.version          = '0.5.2'
   s.summary          = 'A short description of SteamcLog.'
 
 # This description is used to generate tags and improve search results.

--- a/SteamcLog.podspec
+++ b/SteamcLog.podspec
@@ -29,7 +29,7 @@ TODO: Add long description of the pod here.
   s.ios.deployment_target = '11.0'
   
   s.dependency 'XCGLogger', '~> 7.0.1'
-  s.dependency 'Sentry', '~> 5.1'
+  s.dependency 'Sentry', '~> 7.0.0'
 
   s.subspec 'Netable' do |ss|
     ss.source_files = 'Netable/*', 'SteamcLog/Classes/**/*'


### PR DESCRIPTION
## Summary
The newest Sentry SDK is `7.2.1` but we're still on `5.2.0`, so that's quite behind. We should use the latest SDK to minimize chances of problems with the reporting.

## Solution
- Updated Sentry version markers
- Bumped Steamclog version