### PR TITLE
Updated log level presets to better suit default needs (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Un-released
+- Updated LogLevelPreset names and mapped LogLevels (#91)
 
 ## [0.5.4]
 - Update Sentry code and example app

--- a/SteamcLog/Classes/Helper/Config.swift
+++ b/SteamcLog/Classes/Helper/Config.swift
@@ -50,7 +50,7 @@ public struct Config {
      */
     public init(
             sentryKey: String,
-            logLevel: LogLevelPreset = .develop,
+            logLevel: LogLevelPreset = .debug,
             requireRedacted: Bool = false,
             identifier: String = "steamclog",
             autoRotateConfig: AutoRotateConfig = AutoRotateConfig(),

--- a/SteamcLog/Classes/Helper/LogLevelPreset.swift
+++ b/SteamcLog/Classes/Helper/LogLevelPreset.swift
@@ -28,17 +28,17 @@ public enum LogLevelPreset: String, Codable {
         switch self {
         case .debugVerbose: return .none
         case .debug: return .none
-        case .release: return .warn
-        case .releaseAdvanced: return .info
+        case .release: return .info
+        case .releaseAdvanced: return .warn
         }
     }
 
     var disk: LogLevel {
         switch self {
         case .debugVerbose: return .verbose
-        case .debug: return .none
-        case .release: return .none
-        case .releaseAdvanced: return .verbose
+        case .debug: return .debug
+        case .release: return .info
+        case .releaseAdvanced: return .debug
         }
     }
 

--- a/SteamcLog/Classes/Helper/LogLevelPreset.swift
+++ b/SteamcLog/Classes/Helper/LogLevelPreset.swift
@@ -9,57 +9,55 @@
 import Foundation
 
 public enum LogLevelPreset: String, Codable {
-    /// Disk: verbose, system: verbose, remote: none, analytics: disabled
-    case firehose
-    /// Disk: none, system: debug, remote: none, analytics: disabled
-    case develop
-    /// Disk: verbose, system: none, remote: warn, analytics: enabled
-    case releaseAdvanced
-    /// Disk: none, system: none, remote: warn, analytics: enabled
+
+    case debugVerbose
+    case debug
     case release
+    case releaseAdvanced
 
     var global: LogLevel {
         switch self {
-        case .firehose: return .info
-        case .develop: return .info
-        case .releaseAdvanced: return .info
+        case .debugVerbose: return .info
+        case .debug: return .info
         case .release: return .warn
+        case .releaseAdvanced: return .info
         }
     }
 
     var sentry: LogLevel {
         switch self {
-        case .firehose: return .none
-        case .develop: return .none
-        case .releaseAdvanced: return .info
+        case .debugVerbose: return .none
+        case .debug: return .none
         case .release: return .warn
+        case .releaseAdvanced: return .info
         }
     }
 
     var file: LogLevel {
         switch self {
-        case .firehose: return .verbose
-        case .develop: return .none
-        case .releaseAdvanced: return .verbose
+        case .debugVerbose: return .verbose
+        case .debug: return .none
         case .release: return .none
+        case .releaseAdvanced: return .verbose
         }
     }
 
     var system: LogLevel {
         switch self {
-        case .firehose: return .verbose
-        case .develop: return .debug
-        case .releaseAdvanced: return .none
+        case .debugVerbose: return .verbose
+        case .debug: return .debug
         case .release: return .none
+        case .releaseAdvanced: return .none
         }
     }
 
+    // TODO 2021-09-16: If analytics are by default no longer supported, should we remove this?
     var analyticsEnabled: Bool {
         switch self {
-        case .firehose: return false
-        case .develop: return false
-        case .releaseAdvanced: return true
+        case .debugVerbose: return false
+        case .debug: return false
         case .release: return true
+        case .releaseAdvanced: return true
         }
     }
 }

--- a/SteamcLog/Classes/Helper/LogLevelPreset.swift
+++ b/SteamcLog/Classes/Helper/LogLevelPreset.swift
@@ -10,9 +10,16 @@ import Foundation
 
 public enum LogLevelPreset: String, Codable {
 
+    /// console: verbose, disk: verbose, remote: none
     case debugVerbose
+
+    /// console: debug, disk: debug, remote: none
     case debug
+
+    /// console: none, disk: info, remote: info
     case release
+
+    /// console: none, disk: debug, remote: debug
     case releaseAdvanced
 
     var global: LogLevel {
@@ -29,7 +36,7 @@ public enum LogLevelPreset: String, Codable {
         case .debugVerbose: return .none
         case .debug: return .none
         case .release: return .info
-        case .releaseAdvanced: return .warn
+        case .releaseAdvanced: return .debug
         }
     }
 

--- a/SteamcLog/Classes/Helper/LogLevelPreset.swift
+++ b/SteamcLog/Classes/Helper/LogLevelPreset.swift
@@ -24,7 +24,7 @@ public enum LogLevelPreset: String, Codable {
         }
     }
 
-    var sentry: LogLevel {
+    var remote: LogLevel {
         switch self {
         case .debugVerbose: return .none
         case .debug: return .none
@@ -33,7 +33,7 @@ public enum LogLevelPreset: String, Codable {
         }
     }
 
-    var file: LogLevel {
+    var disk: LogLevel {
         switch self {
         case .debugVerbose: return .verbose
         case .debug: return .none
@@ -42,7 +42,7 @@ public enum LogLevelPreset: String, Codable {
         }
     }
 
-    var system: LogLevel {
+    var console: LogLevel {
         switch self {
         case .debugVerbose: return .verbose
         case .debug: return .debug

--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -13,9 +13,9 @@ import XCGLogger
 public struct SteamcLog {
     public var config: Config! {
         didSet {
-            sentryDestination.outputLevel = config.logLevel.sentry.xcgLevel
-            fileDestination.outputLevel = config.logLevel.file.xcgLevel
-            systemDestination.outputLevel = config.logLevel.system.xcgLevel
+            sentryDestination.outputLevel = config.logLevel.console.xcgLevel
+            fileDestination.outputLevel = config.logLevel.disk.xcgLevel
+            systemDestination.outputLevel = config.logLevel.console.xcgLevel
         }
     }
 
@@ -42,19 +42,19 @@ public struct SteamcLog {
         }
 
         sentryDestination = SentryDestination(identifier: "steamclog.sentryDestination")
-        setLoggingDetails(destination: &sentryDestination, outputLevel: config.logLevel.sentry)
+        setLoggingDetails(destination: &sentryDestination, outputLevel: config.logLevel.console)
         xcgLogger.add(destination: sentryDestination)
 
         fileDestination = AutoRotatingFileDestination(writeToFile: logFilePath,
                                                       identifier: "steamclog.fileDestination",
                                                       shouldAppend: true,
                                                       maxTimeInterval: config.autoRotateConfig.fileRotationTime)
-        setLoggingDetails(destination: &fileDestination, outputLevel: config.logLevel.file)
+        setLoggingDetails(destination: &fileDestination, outputLevel: config.logLevel.disk)
         xcgLogger.add(destination: fileDestination)
         fileDestination.logQueue = XCGLogger.logQueue
 
         systemDestination = SteamcLogSystemLogDestination(identifier: "steamclog.systemDestination")
-        setLoggingDetails(destination: &systemDestination, outputLevel: config.logLevel.system)
+        setLoggingDetails(destination: &systemDestination, outputLevel: config.logLevel.console)
         xcgLogger.add(destination: systemDestination)
 
         xcgLogger.logAppDetails()

--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -13,7 +13,7 @@ import XCGLogger
 public struct SteamcLog {
     public var config: Config! {
         didSet {
-            sentryDestination.outputLevel = config.logLevel.console.xcgLevel
+            sentryDestination.outputLevel = config.logLevel.remote.xcgLevel
             fileDestination.outputLevel = config.logLevel.disk.xcgLevel
             systemDestination.outputLevel = config.logLevel.console.xcgLevel
         }
@@ -42,7 +42,7 @@ public struct SteamcLog {
         }
 
         sentryDestination = SentryDestination(identifier: "steamclog.sentryDestination")
-        setLoggingDetails(destination: &sentryDestination, outputLevel: config.logLevel.console)
+        setLoggingDetails(destination: &sentryDestination, outputLevel: config.logLevel.remote)
         xcgLogger.add(destination: sentryDestination)
 
         fileDestination = AutoRotatingFileDestination(writeToFile: logFilePath,


### PR DESCRIPTION
### Related Issue: #91 

### Summary of Problem:
In our TechWG meeting where we reviewed Steamclog usage, we decided on some updates to how LogLevelPresets were named and what their LogLevel mappings were: 
![image](https://user-images.githubusercontent.com/5217641/132917283-d059407f-e9bf-4fb4-a39d-181961c88459.png)

Tech WG Doc: 
https://coda.io/d/Tech-Working-Group_dq8QHMnEi6A/Aug-16th-2021_suivT#_luAHl

### Proposed Solution:
* Updated LogLevelPreset destinations to match spec (ex. remote instead of sentry)
* Updated LogLevelPreset LogLevels (ex. debugVerbose instead of firehose)
* Updated preset mappings 
