### PR TITLE
[72] Set debug/prod flag in Sentry based on #if DEBUG

### DIFF
--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -34,6 +34,14 @@ public struct SteamcLog {
             level: config.logLevel.global.xcgLevel
         )
 
+        SentrySDK.configureScope { scope in
+            #if DEBUG
+            scope.setTag(value: "debug", key: "environment")
+            #else
+            scope.setTag(value: "prod", key: "environment")
+            #endif
+        }
+
         SentrySDK.start { options in
             options.dsn = config.sentryKey
             options.debug = config.sentryDebug


### PR DESCRIPTION
Closes #72 

Adds an environment tag to Sentry issues, labeled "debug" or "prod" based on the `DEBUG` compiler flag.