### PR TITLE
[102] Disable Sentry transaction events

### DIFF
--- a/SteamcLog.podspec
+++ b/SteamcLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SteamcLog'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'A short description of SteamcLog.'
 
 # This description is used to generate tags and improve search results.

--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -47,6 +47,7 @@ public struct SteamcLog {
             options.debug = config.sentryDebug
             options.attachStacktrace = config.sentryAttachStacktrace
             options.enableAutoSessionTracking = config.sentryAutoSessionTracking
+            options.tracesSampleRate = 0.0
         }
 
         sentryDestination = SentryDestination(identifier: "steamclog.sentryDestination")


### PR DESCRIPTION
On newer versions of Sentry, a new performance monitoring feature that sends transaction events ends up enabled by default. This PR sets the [traces sample rate](https://develop.sentry.dev/sdk/performance/#tracessamplerate) to 0, preventing any transaction events from being sent.

Also bumped the patch version.