### PR TITLE
Add support for extra info and detailed logs on user reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
+- Add flag to attach the detailed logs stored on disk to any 'user report' events
+- Add support for adding additional app-specific extra context information to error and user report events.
+- Update to use 8.x versions of Sentry SDK
+
 ## [2.1.0]
 - Add warn/error/fatal entry points that explicitly take an `Error` conforming object as a parameter, for recording more error details
 - Add support, when passing in an Error-conforming object, for downgrading errors to warnings based on a user-supplied predicate and the contents of the error instances

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/DaveWoodCom/XCGLogger", from: "7.0.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "7.0.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.0.0"),
     ],
     targets: [
         .target(

--- a/SteamcLog/Classes/Helper/Config.swift
+++ b/SteamcLog/Classes/Helper/Config.swift
@@ -35,7 +35,7 @@ public struct Config {
     internal let detailedLogsOnUserReports: Bool
 
     /// Set a callback to collect additional app specific properties to associate with an error, called any time a error/fatal/user report is logged. The `purpose` parameter indicates what sort of error this is, particularly to allow the callee to
-    /// associate more personal data with user reports (wher eprivacy issues are less of a concern). Note: unlike the extra info passed into individual logging functions, this info is not redacted in any way even if requireRedacted is set,
+    /// associate more personal data with user reports (where privacy issues are less of a concern). Note: unlike the extra info passed into individual logging functions, this info is not redacted in any way even if requireRedacted is set,
     /// the callback must handle and privacy preservation or redaction
     @usableFromInline internal let extraInfo: (ExtraInfoPurpose) -> [String: Any]?
 

--- a/SteamcLog/Classes/Helper/UserInfoKeys.swift
+++ b/SteamcLog/Classes/Helper/UserInfoKeys.swift
@@ -1,0 +1,14 @@
+//
+//  UserInfoKeys.swift
+//  
+//
+//  Created by Nigel Brooke on 2023-04-26.
+//  Copyright (c) 2022 Steamclock Software, Ltd. All rights reserved.
+//
+
+import Foundation
+
+@usableFromInline enum UserInfoKeys {
+    @usableFromInline static let extraInfo = "steamclogExtraInfo"
+    @usableFromInline static let detailedLogURL = "steamclogDetailedLogURL"
+}

--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -269,7 +269,12 @@ public struct SteamcLog {
     // MARK: Non-static NonFatal Log Level
 
     private func internalUserReport(_ message: String, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
-        xcgLogger.error(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+        let userInfo: [String: Any] = [
+            UserInfoKeys.extraInfo: config.extraInfo(.userReport) as Any,
+            UserInfoKeys.detailedLogURL: (config.detailedLogsOnUserReports ? logFilePath : nil) as Any
+        ]
+
+        xcgLogger.error(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber, userInfo: userInfo)
     }
 
     public func userReport(_ message: String, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
@@ -306,7 +311,11 @@ public struct SteamcLog {
             xcgLogger.info(info, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
         }
 
-        xcgLogger.error(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+        let userInfo: [String: Any] = [
+            UserInfoKeys.extraInfo: config.extraInfo(.error) as Any,
+        ]
+
+        xcgLogger.error(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber, userInfo: userInfo)
     }
 
     public func error(_ message: StaticString, info: String? = nil, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
@@ -370,7 +379,12 @@ public struct SteamcLog {
         if let info = info {
             xcgLogger.info(info, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
         }
-        xcgLogger.severe(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+
+        let userInfo: [String: Any] = [
+            UserInfoKeys.extraInfo: config.extraInfo(.fatal) as Any,
+        ]
+
+        xcgLogger.severe(message, functionName: functionName, fileName: fileName, lineNumber: lineNumber, userInfo: userInfo)
 
         // forcing a crash, so we get a stacktrace
         let cleanfileName = ("\(fileName)" as NSString).lastPathComponent.replacingOccurrences(of: ".swift", with: "")


### PR DESCRIPTION
Fixes: #81

Changes Made:

This PR adds support for two new features:
- A new config value that enables automatically attaching the detailed logs stored on disk to user reports as file attachments in Sentry.
- A new configuration callback that allows associating additional app-specific properties with any error or user report that will display alongside information like the OS version, app version, device type, etc in the Sentry reports.

It also upgrades Steamclock to use the 8.x version of the Sentry SDK (which is required for the file attachments).

Technical design notes:

- Although these new features are currently fairly Sentry specific, the configuration properties are in the main Config struct, since if we ever did switch backends we would likely want to continue to support them.
- Detailed logs COULD be attached to other errors, but that seem to privacy-violating, whereas in the user report case the user (should be) more aware of / consenting to the additional data being collected.
- The extra info callback doesn't perform any sort of redaction by default, unlike other cases where we potentially send "random" info from other data sources. Since that info is generated specifically for this purpose it seems reasonable to require that the callback makes the decision about what info is and isn't included. The callback does distinguish between different types of errors (user report vs error vs fatal), so you can potentially do more privacy preservation on automatically logged errors than user reports. 
- Our internal sentry testbed has some changes to test this if you are interested in running it, on the `nb/detailed-logs-and-extra-info` branch. You likely need to add a local copy of the Steamclog package to the project do that since that branch does not specifically target this one.

Screenshot:

![Screenshot 2023-05-03 at 10 50 36 AM](https://user-images.githubusercontent.com/275128/236002607-4d6f76e8-6f96-4984-b5d1-7a6c703535a4.png)


