### PR TITLE
Attach most recent archived log to user reports as well as current log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1]
+- Detail log attachment now includes most recent archived log as well as current
+
 ## [2.2.0]
 - Add flag to attach the detailed logs stored on disk to any 'user report' events
 - Add support for adding additional app-specific extra context information to error and user report events.

--- a/SteamcLog/Classes/Destinations/SentryLogDestination.swift
+++ b/SteamcLog/Classes/Destinations/SentryLogDestination.swift
@@ -53,8 +53,9 @@ class SentryDestination: BaseQueuedDestination {
             event.message = SentryMessage(formatted: logDetails.message)
             event.extra = logDetails.userInfo[UserInfoKeys.extraInfo] as? [String: Any]
             SentrySDK.capture(event: event) { scope in
-                if let logURL = logDetails.userInfo[UserInfoKeys.detailedLogURL] as? URL {
-                    scope.addAttachment(Attachment(path: logURL.path))
+                let urls = (logDetails.userInfo[UserInfoKeys.detailedLogURLs] as? [URL]) ?? []
+                for url in urls {
+                    scope.addAttachment(Attachment(path: url.path))
                 }
             }
         }

--- a/SteamcLog/Classes/Helper/UserInfoKeys.swift
+++ b/SteamcLog/Classes/Helper/UserInfoKeys.swift
@@ -10,5 +10,5 @@ import Foundation
 
 @usableFromInline enum UserInfoKeys {
     @usableFromInline static let extraInfo = "steamclogExtraInfo"
-    @usableFromInline static let detailedLogURL = "steamclogDetailedLogURL"
+    @usableFromInline static let detailedLogURLs = "steamclogDetailedLogURLs"
 }

--- a/SteamcLog/Classes/SteamcLog.swift
+++ b/SteamcLog/Classes/SteamcLog.swift
@@ -289,7 +289,7 @@ public struct SteamcLog {
         var detailedLogPaths: [URL] = []
 
         if config.detailedLogsOnUserReports {
-            detailedLogPaths = [logFilePath, previousLogFilePath].compactMap({$0})
+            detailedLogPaths = [logFilePath, previousLogFilePath].compactMap { $0 }
         }
 
         let userInfo: [String: Any] = [


### PR DESCRIPTION
## For: #111

## Problem:

The detailed log file attachment for user reports only includes the current log, which means if a log rotation happens right before a user report, you may have much shorter past logs than expected.

## Proposed solution:

Always attach both the current log AND the most recent archived log, so that you should have between `fileRotationTime` and `2 * fileRotationTime` worth of logs, whereas now you have between `0` and `fileRotationTime` worth of logs.
